### PR TITLE
fix: unify token storage and logout flow across app

### DIFF
--- a/src/components/SignOutButton.jsx
+++ b/src/components/SignOutButton.jsx
@@ -1,13 +1,38 @@
 import React from 'react'
+import { setToken } from '../lib/api';
+import { useNavigate } from 'react-router-dom';
 
-const SignOutButton = () => {
+/**
+ * SignOutButton
+ * - Clears auth token and emits "auth:changed"
+ * - Navigates to `redirectTo` (defaults to "/")
+ * - Optionally uses history.replace (no back to the signed-in page)
+ */
+const SignOutButton = ({ redirectTo = '/', replace = true, onSignedOut }) => {
 
+    const navigate = useNavigate()
     const handleSignOut = () => {
-        // Clear user session data (e.g., tokens, user info)
-        localStorage.removeItem('authToken');
-        sessionStorage.removeItem('authToken');
+        setToken(null, false)         // clear token + remember flag + dispatch event
+        onSignedOut?.()               // optional callback (e.g., toast)
+        navigate(redirectTo, { replace })
 
-        window.location.reload() // Reload the app to reflect signed-out state
+        // --- Legacy SignOutButton implementation ---
+        // This version manually cleared tokens from localStorage/sessionStorage
+        // and forced a full page reload with window.location.reload().
+        // It worked, but:
+        //   - Did not clear the "rememberLogin" flag
+        //   - Did not reset the in-memory _token
+        //   - Did not dispatch the "auth:changed" event
+        //   - Reloading the whole SPA was heavy and unnecessary
+        //
+        // Kept temporarily for reference/rollback during testing.
+        // Safe to delete once the new SPA-style logout is fully verified.
+        //
+        // // Clear user session data (e.g., tokens, user info)
+        // localStorage.removeItem('authToken');
+        // sessionStorage.removeItem('authToken');
+
+        // window.location.reload() // Reload the app to reflect signed-out state
     }
 
     return (

--- a/src/lib/api.js
+++ b/src/lib/api.js
@@ -1,143 +1,205 @@
-import {createClient} from "./http";
- // Simple in-memory token storage 
- // In a real app, consider more secure storage
-let _token = null;
+  import {createClient} from "./http";
+  // Simple in-memory token storage 
+  // In a real app, consider more secure storage
+  let _token = null;
 
-export function setToken(token){ // Sets the current auth token
-    _token = token;
-    if (token) localStorage.setItem('authToken', token);
-    else localStorage.removeItem('authToken');
-}
+  /**
+   * Store the auth token in storage.
+   * - Uses localStorage if "remember" is true, otherwise sessionStorage.
+   * - Clears previous tokens and updates the "rememberLogin" flag.
+   * - Dispatches "auth:changed" so the app can react to login/logout.
+   */
+  export function setToken(token, remember) {
+    _token = token || null
 
-export function getToken(){ // Retrieves the current auth token
-    if (_token) return _token;
-    const saved = localStorage.getItem('authToken');
-    if (saved) _token = saved;
-    return _token;
-}
-// Environment variables for API base URLs. Add the const you want to add to the api if leter are developped.
-const EVENTS_BASE        = import.meta.env.VITE_EVENTS_API_BASE_URL        || ''
-const AUTH_BASE          = import.meta.env.VITE_AUTH_API_BASE_URL          || ''
-const VENUES_BASE        = import.meta.env.VITE_VENUES_API_BASE_URL        || ''
-const BOOKINGS_BASE      = import.meta.env.VITE_BOOKINGS_API_BASE_URL      || ''
-const NOTIFICATIONS_BASE = import.meta.env.VITE_NOTIFICATIONS_API_BASE_URL || ''
+    // Clear both storages first
+    localStorage.removeItem('authToken')
+    sessionStorage.removeItem('authToken')
 
-export const authApi = createClient({ // Wrapper for auth API calls
-    baseUrl: AUTH_BASE, // Base URL for the auth API
-    getToken, // Function to get the current auth token
-    unwrapResult: false,
-    timeout: 30000,
-    retries: 1, // Automatically return the 'result' field from responses
-});
-export const eventsApi = createClient({ // Wrapper for auth API calls
-    baseUrl: EVENTS_BASE, // Base URL for the events API
-    unwrapResult: true, // Automatically return the 'result' field from responses
-});
-export const venuesApi = createClient({ // Wrapper for auth API calls
-    baseUrl: VENUES_BASE, // Base URL for the auth API
-    unwrapResult: true, // Automatically return the 'result' field from responses
-});
-export const bookingsApi = createClient({
-  baseUrl: BOOKINGS_BASE,
-  getToken,
-  unwrapResult: true,
-})
-export const notificationsApi = createClient({
-  baseUrl: NOTIFICATIONS_BASE,
-  getToken,            
-  unwrapResult: true,
-})
+    if (token) {
+      if (remember) {
+        // Persist in localStorage and set remember flag
+        localStorage.setItem('authToken', token)
+        localStorage.setItem('rememberLogin', '1')
+      } else {
+        // Persist in sessionStorage only
+        sessionStorage.setItem('authToken', token)
+        localStorage.removeItem('rememberLogin')
+      }
+    } else {
+      // Remove remember flag when logging out
+      localStorage.removeItem('rememberLogin')
+    }
 
-
-//JWT parsing utility
-const ROLE_CLAIM_KEYS = [
-  'role',
-  'roles',
-  'http://schemas.microsoft.com/ws/2008/06/identity/claims/role'
-]
-
-export function getRolesFromToken() {
-  const token = getToken()
-  if (!token) return []
-  const claims = parseJwt(token) || {}
-  for (const key of ROLE_CLAIM_KEYS) {
-    const raw = claims[key]
-    if (!raw) continue
-    if (Array.isArray(raw)) return raw.map(String)
-    return [String(raw)]
+    // Notify app that auth state has changed
+    window.dispatchEvent(new Event('auth:changed'))
   }
-  return []
-}
 
-export function parseJwt(token) {
-  try {
-    const base64 = token.split('.')[1]
-    const json = atob(base64.replace(/-/g, '+').replace(/_/g, '/'))
-    return JSON.parse(json)
-  } catch { return null }
-}
+  /**
+   * Retrieve the current auth token.
+   * - Returns the in-memory token if available.
+   * - Otherwise checks localStorage (if "rememberLogin" is set) or sessionStorage.
+   * - Updates in-memory cache when a stored token is found.
+   */
+  export function getToken() {
+    if (_token) return _token
 
-export function getUserIdFromToken() {
-  const token = getToken()
-  if (!token) return ''
-  const claims = parseJwt(token) || {}
-  // justera efter dina claims (sub/nameid/uid)
-  return claims.sub || claims.nameid || claims.uid || ''
-}
-// --- Helpers for specific API endpoints ---
+    const remember = localStorage.getItem('rememberLogin')
+    if (remember) {
+      const t = localStorage.getItem('authToken')
+      if (t) { _token = t; return t }
+    }
+    const s = sessionStorage.getItem('authToken')
+    if (s) { _token = s; return s }
 
-// EventService
-export const Events = {
-  list:   (opts)                      => eventsApi.get('/api/Events', opts),
-  get:    (id, opts)                  => eventsApi.get(`/api/Events/${id}`, opts),
-  create: (body)                      => eventsApi.post('/api/Events', body),
-  update: (id, body)                  => eventsApi.put(`/api/Events/${id}`, body),
-  remove: (id)                        => eventsApi.delete(`/api/Events/${id}`),
-  upcoming:  (opts)                   => eventsApi.get('/api/Events/upcoming', opts),
-  byDateRange: (fromIso, toIso, opts) => eventsApi.get('/api/Events/date-range', { ...opts, params: { from: fromIso, to: toIso } }),
-}
+    return null
+  }
 
-// Venue/LocationService
+  // --- Legacy implementation (before token sync fix) ---
+  // NOTE: This version always stored tokens in localStorage and did not fully respect
+  //       "remember me" vs session-only login. It sometimes caused mismatched login state
+  //       between pages (list vs details).
+  //       Kept here temporarily for reference/rollback during testing.
+  //       Remove once new implementation has been verified stable.
+  //
+  // Sets the current auth token
+  // export function setToken(token){
+  //     _token = token;
+  //     if (token) localStorage.setItem('authToken', token);
+  //     else localStorage.removeItem('authToken');
+  // }
 
-export const Venues = {
-  locations: {
-    list:   (opts)      => venuesApi.get('/api/Locations', opts),
-    get:    (id, opts)  => venuesApi.get(`/api/Locations/${id}`, opts),
-    create: (body)      => venuesApi.post('/api/Locations', body),
-    update: (id, body)  => venuesApi.put(`/api/Locations/${id}`, body),
-    remove: (id)        => venuesApi.delete(`/api/Locations/${id}`),
-  },
-  rooms: {
-    list:       (opts)         => venuesApi.get('/api/LocationRooms', opts),
-    get:        (id, opts)     => venuesApi.get(`/api/LocationRooms/${id}`, opts),
-    create:     (body)         => venuesApi.post('/api/LocationRooms', body),
-    update:     (id, body)     => venuesApi.put(`/api/LocationRooms/${id}`, body),
-    remove:     (id)           => venuesApi.delete(`/api/LocationRooms/${id}`),
-    byLocation: (locationId, opts) =>
-      venuesApi.get(`/api/LocationRooms/${locationId}/rooms`, opts), // enligt din lista
-  },
-}
+  // Retrieves the current auth token
+  // export function getToken(){
+  //     if (_token) return _token;
+  //     const saved = localStorage.getItem('authToken');
+  //     if (saved) _token = saved;
+  //     return _token;
+  // }
 
-// BookingService
-export const Bookings = {
-  create:        (body)                => bookingsApi.post('/api/Bookings', body),
-  byUser:        (userId, opts)        => bookingsApi.get(`/api/Bookings/user/${userId}`, opts),
-  deleteByUser:  (userId)              => bookingsApi.delete(`/api/Bookings/user/${userId}`),
-  participants:  (eventId, opts)       => bookingsApi.get(`/api/Bookings/event/${eventId}/participants`, opts),
-  delete:        (bookingId)           => bookingsApi.delete(`/api/Bookings/${bookingId}`),
-  deleteByEvent: (eventId)             => bookingsApi.delete(`/api/Bookings/event/${eventId}`),
-}
+  // Environment variables for API base URLs. Add the const you want to add to the api if leter are developped.
+  const EVENTS_BASE        = import.meta.env.VITE_EVENTS_API_BASE_URL        || ''
+  const AUTH_BASE          = import.meta.env.VITE_AUTH_API_BASE_URL          || ''
+  const VENUES_BASE        = import.meta.env.VITE_VENUES_API_BASE_URL        || ''
+  const BOOKINGS_BASE      = import.meta.env.VITE_BOOKINGS_API_BASE_URL      || ''
+  const NOTIFICATIONS_BASE = import.meta.env.VITE_NOTIFICATIONS_API_BASE_URL || ''
 
-// NotificationService
-export const Notifications = {
-  bookingEmailConfirmation: (body) => notificationsApi.post('/api/BookingEmail/confirmation', body),
-}
+  export const authApi = createClient({ // Wrapper for auth API calls
+      baseUrl: AUTH_BASE, // Base URL for the auth API
+      getToken, // Function to get the current auth token
+      unwrapResult: false,
+      timeout: 30000,
+      retries: 1, // Automatically return the 'result' field from responses
+  });
+  export const eventsApi = createClient({ // Wrapper for auth API calls
+      baseUrl: EVENTS_BASE, // Base URL for the events API
+      unwrapResult: true, // Automatically return the 'result' field from responses
+  });
+  export const venuesApi = createClient({ // Wrapper for auth API calls
+      baseUrl: VENUES_BASE, // Base URL for the auth API
+      unwrapResult: true, // Automatically return the 'result' field from responses
+  });
+  export const bookingsApi = createClient({
+    baseUrl: BOOKINGS_BASE,
+    getToken,
+    unwrapResult: true,
+  })
+  export const notificationsApi = createClient({
+    baseUrl: NOTIFICATIONS_BASE,
+    getToken,            
+    unwrapResult: true,
+  })
 
-// --- Bundle and export all API utilities --- 
-const api = {
-  authApi, eventsApi, venuesApi, bookingsApi, notificationsApi,
-  Events, Venues, Bookings, Notifications,
-  setToken, getToken, parseJwt, getUserIdFromToken,
-  getRolesFromToken,
-}
-export default api;
+
+  //JWT parsing utility
+  const ROLE_CLAIM_KEYS = [
+    'role',
+    'roles',
+    'http://schemas.microsoft.com/ws/2008/06/identity/claims/role'
+  ]
+
+  export function getRolesFromToken() {
+    const token = getToken()
+    if (!token) return []
+    const claims = parseJwt(token) || {}
+    for (const key of ROLE_CLAIM_KEYS) {
+      const raw = claims[key]
+      if (!raw) continue
+      if (Array.isArray(raw)) return raw.map(String)
+      return [String(raw)]
+    }
+    return []
+  }
+
+  export function parseJwt(token) {
+    try {
+      const base64 = token.split('.')[1]
+      const json = atob(base64.replace(/-/g, '+').replace(/_/g, '/'))
+      return JSON.parse(json)
+    } catch { return null }
+  }
+
+  export function getUserIdFromToken() {
+    const token = getToken()
+    if (!token) return ''
+    const claims = parseJwt(token) || {}
+    // justera efter dina claims (sub/nameid/uid)
+    return claims.sub || claims.nameid || claims.uid || ''
+  }
+  // --- Helpers for specific API endpoints ---
+
+  // EventService
+  export const Events = {
+    list:   (opts)                      => eventsApi.get('/api/Events', opts),
+    get:    (id, opts)                  => eventsApi.get(`/api/Events/${id}`, opts),
+    create: (body)                      => eventsApi.post('/api/Events', body),
+    update: (id, body)                  => eventsApi.put(`/api/Events/${id}`, body),
+    remove: (id)                        => eventsApi.delete(`/api/Events/${id}`),
+    upcoming:  (opts)                   => eventsApi.get('/api/Events/upcoming', opts),
+    byDateRange: (fromIso, toIso, opts) => eventsApi.get('/api/Events/date-range', { ...opts, params: { from: fromIso, to: toIso } }),
+  }
+
+  // Venue/LocationService
+
+  export const Venues = {
+    locations: {
+      list:   (opts)      => venuesApi.get('/api/Locations', opts),
+      get:    (id, opts)  => venuesApi.get(`/api/Locations/${id}`, opts),
+      create: (body)      => venuesApi.post('/api/Locations', body),
+      update: (id, body)  => venuesApi.put(`/api/Locations/${id}`, body),
+      remove: (id)        => venuesApi.delete(`/api/Locations/${id}`),
+    },
+    rooms: {
+      list:       (opts)         => venuesApi.get('/api/LocationRooms', opts),
+      get:        (id, opts)     => venuesApi.get(`/api/LocationRooms/${id}`, opts),
+      create:     (body)         => venuesApi.post('/api/LocationRooms', body),
+      update:     (id, body)     => venuesApi.put(`/api/LocationRooms/${id}`, body),
+      remove:     (id)           => venuesApi.delete(`/api/LocationRooms/${id}`),
+      byLocation: (locationId, opts) =>
+        venuesApi.get(`/api/LocationRooms/${locationId}/rooms`, opts), // enligt din lista
+    },
+  }
+
+  // BookingService
+  export const Bookings = {
+    create:        (body)                => bookingsApi.post('/api/Bookings', body),
+    byUser:        (userId, opts)        => bookingsApi.get(`/api/Bookings/user/${userId}`, opts),
+    deleteByUser:  (userId)              => bookingsApi.delete(`/api/Bookings/user/${userId}`),
+    participants:  (eventId, opts)       => bookingsApi.get(`/api/Bookings/event/${eventId}/participants`, opts),
+    delete:        (bookingId)           => bookingsApi.delete(`/api/Bookings/${bookingId}`),
+    deleteByEvent: (eventId)             => bookingsApi.delete(`/api/Bookings/event/${eventId}`),
+  }
+
+  // NotificationService
+  export const Notifications = {
+    bookingEmailConfirmation: (body) => notificationsApi.post('/api/BookingEmail/confirmation', body),
+  }
+
+  // --- Bundle and export all API utilities --- 
+  const api = {
+    authApi, eventsApi, venuesApi, bookingsApi, notificationsApi,
+    Events, Venues, Bookings, Notifications,
+    setToken, getToken, parseJwt, getUserIdFromToken,
+    getRolesFromToken,
+  }
+  export default api;

--- a/src/pages/StartPage.jsx
+++ b/src/pages/StartPage.jsx
@@ -1,12 +1,13 @@
 import React from 'react'
 import { Link } from 'react-router-dom'
+import Logotype from '../img/logo.png'
 
 
 const StartPage = () => {
   return (
     <main className="landing-container" aria-labelledby="welcome-heading">
       <div className="logo-container animate__animated animate__flip">
-        <img src="\src\img\logo.png" alt="Core Gym Club" className="landing-logo" />
+        <img src={Logotype} alt="Core Gym Club" className="landing-logo" />
       </div>
 
       <section className="text-container animate__animated animate__fadeInLeft">
@@ -38,6 +39,7 @@ const StartPage = () => {
         <Link to="/om" className="browse-link">Klicka här</Link>
         </p>
       </aside>
+
 </main>
   )
 }

--- a/src/style.css
+++ b/src/style.css
@@ -114,6 +114,9 @@ p, li, span, label {
   --clr-info: #4AA3FF;
   --clr-success: #32D296;
   --clr-warning: #FFB454;
+
+  --font-fa-free: "Font Awesome 7 Free";
+  --font-fa-brands: "Font Awesome 7 Brands";
 }
 
 


### PR DESCRIPTION
### Changes included

**api.js**

- Refactored setToken and getToken to properly support both localStorage (remember me) and sessionStorage.
- Added global auth:changed event dispatch to notify the app of login/logout.
- Legacy implementation kept as commented code for rollback during testing.

**SessionListPage**

- Replaced legacy hasToken check with hasTokenAndIsValid.
- Added listeners for auth:changed, storage, and visibilitychange to ensure UI stays in sync with token state.
- Legacy code left commented for reference.

**SignOutButton**

- Replaced full-page reload with SPA-style logout using setToken(null, false) and navigate.
- Clears tokens, resets in-memory state, and prevents “phantom logins”.
- Legacy button implementation left commented for rollback.

Why
Previously, auth state could become inconsistent: list page showed logged out while details page still read userId. Logout also failed to clear all state and required a full reload. This PR ensures consistent login/logout behavior across the app.