### PR TITLE
fix(SessionCard): use participant count from API directly

### DIFF
--- a/src/components/SessionCard.jsx
+++ b/src/components/SessionCard.jsx
@@ -14,14 +14,13 @@ const SessionCard = ({item}) => {
       try {
         // hämta antal bokade
         const participants = await bookingsApi.get(`/api/Bookings/event/${item.id}/participants`);
-        const count = Array.isArray(participants) ? participants.length : 0;
 
         // hämta rummet för kapacitet
         const room = await venuesApi.get(`/api/LocationRooms/${item.roomId}`);
         const cap = room?.roomCapacity ?? 0;
 
         if (active) {
-          setBooked(count);
+          setBooked(participants);
           setRoomCapacity(cap); // FIX
         }
       } catch (err) {

--- a/src/style.css
+++ b/src/style.css
@@ -1229,6 +1229,7 @@ header {
     margin-bottom: 1rem;
     background-color: transparent;
     place-self: center;
+    padding: .5rem;
 
     &:hover {
       text-decoration: underline;
@@ -1261,6 +1262,7 @@ header {
   input {
     font-size: .75rem;
     padding: .3rem;
+    border-radius: .5rem;
     
     @media (min-width: 768px) {
       font-size: 1rem;


### PR DESCRIPTION
This PR fixes the participant count display on SessionCard.

The frontend previously assumed the API returned a list of participants and attempted to count them. However, the API actually returns the participant count directly as a number.

Updated the code to use the API response directly and removed the unnecessary .length logic.