### PR TITLE
Hide and protect Profile link/route

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import StartPage from './pages/StartPage'
 import AboutPage from './pages/AboutPage'
 import SessionDetailsPage from './pages/SessionDetailsPage'
 import ProfilePage from './pages/ProfilePage'
+import RequireAuth from './routes/RequireAuth'
 
 
 function App() {
@@ -22,7 +23,13 @@ function App() {
         <Route path='/pass' element={<SessionListPage />} />
         <Route path='/pass/info/:id' element={<SessionDetailsPage />} />
         <Route path='/om' element={<AboutPage />} />
-        <Route path='/profil' element={<ProfilePage />} />
+
+        {/* Protected group */}
+        <Route element={<RequireAuth />}>
+          <Route path='/profil' element={<ProfilePage />} />
+          {/* add more protected routes here later */}
+        </Route>
+
       </Route>
 
 

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -1,19 +1,27 @@
-  import React, {useState} from 'react'
+  import React, { useEffect, useState} from 'react'
   import { v4 as uuidv4 } from 'uuid';
   import NavigationLink from './NavigationLink';
   import CoreLogotype from '../img/core.png'
   import ThemeToggle from './ThemeToggle';
+  import { getToken } from '../lib/api';
 
   const Header = () => {
-
+    const [token, setToken] = useState(() => getToken());
+    const isAuthed = !!token;
     const [menuOpen, setMenuOpen] = useState(false)
 
-      const [navLinks, setNavLinks] = useState([
-          { id: uuidv4(), name: "Start", to: "/" },
-          { id: uuidv4(), name: "Pass", to: "/pass" },
-          { id: uuidv4(), name: "Om Oss", to: "/om" },
-          { id: uuidv4(), name: "Min Profil", to: "/profil" },
-      ]);
+    useEffect(() => {
+      const onAuthChanged = () => setToken(getToken());
+      window.addEventListener("auth:changed", onAuthChanged);
+      return () => window.removeEventListener("auth:changed", onAuthChanged);
+    }, []);
+
+    const navLinks = [
+      { id: uuidv4(), name: "Start", to: "/" },
+      { id: uuidv4(), name: "Pass", to: "/pass" },
+      { id: uuidv4(), name: "Om Oss", to: "/om" },
+      ...(isAuthed ? [{id: uuidv4(), name: "Min Profil", to: "/profil"}] : [])
+    ]
 
     return (
       <header>

--- a/src/routes/RequireAuth.jsx
+++ b/src/routes/RequireAuth.jsx
@@ -1,0 +1,16 @@
+import React from 'react'
+import { getToken } from '../lib/api'
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+
+const RequireAuth = () => {
+    const token = getToken();
+    const location = useLocation();
+
+    if (!token) {
+        return <Navigate to="/" replace state={{ from: location }} />;
+    }
+
+    return <Outlet />;
+};
+
+export default RequireAuth


### PR DESCRIPTION
### Summary
This PR introduces authentication checks for the profile feature. The "Min Profil" navigation link is now only shown when the user is signed in, and the /profil route itself is protected so unauthenticated users cannot access it directly.

### Changes
- Added conditional rendering in Header to hide the "Min Profil" link when not authenticated.
- Introduced RequireAuth route guard to block unauthenticated access to /profil.
- Wired auth state updates into the header using the existing auth:changed event.

### Why
Previously, the "Min Profil" link was always visible, and the /profil page could be accessed by anyone with the URL. This update ensures the profile section is only available to authenticated users, improving both UX and security.